### PR TITLE
[L10] Repeated code

### DIFF
--- a/src/BasicTokenAdapters.sol
+++ b/src/BasicTokenAdapters.sol
@@ -101,6 +101,7 @@ contract BasicCollateralJoin {
         collateralType  = collateralType_;
         collateral      = CollateralLike(collateral_);
         decimals        = collateral.decimals();
+        require(decimals == 18, "BasicCollateralJoin/non-18-decimals");
         emit AddAuthorization(msg.sender);
     }
     /**

--- a/src/StabilityFeeTreasury.sol
+++ b/src/StabilityFeeTreasury.sol
@@ -196,9 +196,7 @@ contract StabilityFeeTreasury {
     function disableContract() external isAuthorized {
         require(contractEnabled == 1, "StabilityFeeTreasury/already-disabled");
         contractEnabled = 0;
-        if (systemCoin.balanceOf(address(this)) > 0) {
-          coinJoin.join(address(this), systemCoin.balanceOf(address(this)));
-        }
+        joinAllCoins();
         safeEngine.transferInternalCoins(address(this), accountingEngine, safeEngine.coinBalance(address(this)));
         emit DisableContract();
     }

--- a/src/TaxCollector.sol
+++ b/src/TaxCollector.sol
@@ -438,6 +438,7 @@ contract TaxCollector {
     /**
      * @notice Get how much SF will be distributed after taxing a specific collateral type
      * @param collateralType Collateral type to compute the taxation outcome for
+     * @returns The newly accumulated rate as well as the delta between the new and the last accumulated rates
      */
     function taxSingleOutcome(bytes32 collateralType) public view returns (uint256, int256) {
         (, uint256 lastAccumulatedRate) = safeEngine.collateralTypes(collateralType);

--- a/src/TaxCollector.sol
+++ b/src/TaxCollector.sol
@@ -438,7 +438,7 @@ contract TaxCollector {
     /**
      * @notice Get how much SF will be distributed after taxing a specific collateral type
      * @param collateralType Collateral type to compute the taxation outcome for
-     * @returns The newly accumulated rate as well as the delta between the new and the last accumulated rates
+     * @return The newly accumulated rate as well as the delta between the new and the last accumulated rates
      */
     function taxSingleOutcome(bytes32 collateralType) public view returns (uint256, int256) {
         (, uint256 lastAccumulatedRate) = safeEngine.collateralTypes(collateralType);


### PR DESCRIPTION
Partially fixed with:

- Lines 199-201 of the disableContract function in the StabilityFeeTreasury contract are the same as the joinAllCoins function.
- getApproximateCollateralBought and getCollateralBought functions of the FixedDiscountCollateralAuctionHouse contract are almost identical.